### PR TITLE
Tell Sledge support is over

### DIFF
--- a/twhl.js
+++ b/twhl.js
@@ -43,7 +43,7 @@ bot.on('message', function(user, userID, channelID, message, evt) {
             case 'sledge':
                 bot.sendMessage({
                     to: channelID,
-                    message: 'You can download **Sledge** here: http://sledge-editor.com/'
+                    message: '**Sledge is no longer supported**. You can still download it here: http://sledge-editor.com/'
                 });
                 break;
             // !sharplife


### PR DESCRIPTION
The change at the end of the file (new line feed) wasn't intended, that's GitHub's web "IDE" doing.